### PR TITLE
RFE: add memory access mode to the sysbench memory output

### DIFF
--- a/arcaflow_plugin_sysbench/sysbench_plugin.py
+++ b/arcaflow_plugin_sysbench/sysbench_plugin.py
@@ -201,6 +201,7 @@ def RunSysbenchMemory(
 
     try:
         output, results = run_sysbench(memory_flags, "memory")
+        output["memory_access_mode"] = params.memory_access_mode
     except Exception as error:
         return "error", WorkloadError(error.args[0], error.args[1])
 

--- a/arcaflow_plugin_sysbench/sysbench_schema.py
+++ b/arcaflow_plugin_sysbench/sysbench_schema.py
@@ -244,7 +244,7 @@ class SysbenchMemoryInputParams(CommonInputParameters):
         schema.id("memory-access-mode"),
         schema.name("Memory Access Mode"),
         schema.description("memory access mode (seq,rnd)"),
-    ] = None
+    ] = SeqRnd.SEQ
 
 
 @dataclass
@@ -526,6 +526,11 @@ class SysbenchMemoryOutput:
         schema.description(
             "Total number of operations performed by the memory workload"
         ),
+    ]
+    memory_access_mode: typing.Annotated[
+        SeqRnd,
+        schema.name("Memory Access Mode"),
+        schema.description("memory access mode (seq,rnd)"),
     ]
 
 

--- a/tests/test_arcaflow_plugin_sysbench.py
+++ b/tests/test_arcaflow_plugin_sysbench.py
@@ -60,6 +60,7 @@ class SysbenchPluginTest(unittest.TestCase):
                     "Totaloperationspersecond": 7221925.38,
                     "totaltime": 10.0001,
                     "totalnumberofevents": 72227995,
+                    "memory_access_mode": "rnd",
                 }
             )
         )


### PR DESCRIPTION
## Changes introduced with this PR

Per user request, adding the value of the `memory-access-mode` input value to the output of the `sysbenchmemory` step. This also required setting this input parameter to a default value instead of `None`. Unfortunately the `sysbench` command itself does not return this setting in its own output, so this was the best option to pass through to the plugin output.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).