### PR TITLE
lock installed sysbench version and report version in output schema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG package=arcaflow_plugin_sysbench
 FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-buildbase:0.4.2 as build
 ARG package
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
- && dnf -y install sysbench
+ && dnf -y install sysbench-1.0.20-5.el8
 
 COPY poetry.lock /app/
 COPY pyproject.toml /app/
@@ -32,7 +32,7 @@ FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-osbase:0.4.2
 ARG package
 
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
- && dnf -y install sysbench
+ && dnf -y install sysbench-1.0.20-5.el8
 
 COPY --from=build /app/requirements.txt /app/
 COPY --from=build /htmlcov /htmlcov/

--- a/README.md
+++ b/README.md
@@ -270,6 +270,9 @@ Run CPU performance test using the sysbench workload
         </details><details><summary>Validationchecks (<code>string</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>Validation checks</td></tr><tr><th>Description:</th><td width="500">Validation on/off</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tr>
 </tbody></table>
+        </details><details><summary>sysbenchversion (<code>string</code>)</summary>
+        <table><tbody><tr><th>Name:</th><td>Sysbench version</td></tr><tr><th>Description:</th><td width="500">Version as reported by sysbench</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tr>
+</tbody></table>
         </details><details><summary>totalnumberofevents (<code>int</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>Total number of events</td></tr><tr><th>Description:</th><td width="500">Total number of events performed by the workload</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>int</code></td>
 </tr>
@@ -729,6 +732,9 @@ Run the I/O test using the sysbench workload
         </details><details><summary>Validationchecks (<code>string</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>Validation checks</td></tr><tr><th>Description:</th><td width="500">Validation on/off</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tr>
 </tbody></table>
+        </details><details><summary>sysbenchversion (<code>string</code>)</summary>
+        <table><tbody><tr><th>Name:</th><td>Sysbench version</td></tr><tr><th>Description:</th><td width="500">Version as reported by sysbench</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tr>
+</tbody></table>
         </details><details><summary>totalnumberofevents (<code>int</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>Total number of events</td></tr><tr><th>Description:</th><td width="500">Total number of events performed by the workload</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>int</code></td>
 </tr>
@@ -1126,6 +1132,9 @@ Run the Memory functions speed test using the sysbench workload
 </tbody></table>
         </details><details><summary>scope (<code>string</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>Scope</td></tr><tr><th>Description:</th><td width="500">scope of operation</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tr>
+</tbody></table>
+        </details><details><summary>sysbenchversion (<code>string</code>)</summary>
+        <table><tbody><tr><th>Name:</th><td>Sysbench version</td></tr><tr><th>Description:</th><td width="500">Version as reported by sysbench</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tr>
 </tbody></table>
         </details><details><summary>totalnumberofevents (<code>int</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>Total number of events</td></tr><tr><th>Description:</th><td width="500">Total number of events performed by the workload</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>int</code></td>

--- a/arcaflow_plugin_sysbench/sysbench_plugin.py
+++ b/arcaflow_plugin_sysbench/sysbench_plugin.py
@@ -159,7 +159,8 @@ def get_sysbench_version():
 def RunSysbenchCpu(
     params: SysbenchCpuInputParams,
 ) -> typing.Tuple[str, typing.Union[WorkloadResultsCpu, WorkloadError]]:
-    print(f"Sysbench version is: {get_sysbench_version()}")
+    version = get_sysbench_version()
+    print(f"Sysbench version is: {version}")
     print("==>> Running sysbench CPU workload ...")
 
     serialized_params = sysbench_cpu_input_schema.serialize(params)
@@ -174,6 +175,8 @@ def RunSysbenchCpu(
         return "error", WorkloadError(error.args[0], error.args[1])
 
     print("==>> Workload run complete!")
+
+    output["sysbenchversion"] = version
 
     return "success", WorkloadResultsCpu(
         sysbench_cpu_output_schema.unserialize(output),
@@ -190,7 +193,8 @@ def RunSysbenchCpu(
 def RunSysbenchMemory(
     params: SysbenchMemoryInputParams,
 ) -> typing.Tuple[str, typing.Union[WorkloadResultsMemory, WorkloadError]]:
-    print(f"Sysbench version is: {get_sysbench_version()}")
+    version = get_sysbench_version()
+    print(f"Sysbench version is: {version}")
     print("==>> Running sysbench Memory workload ...")
 
     serialized_params = sysbench_memory_input_schema.serialize(params)
@@ -207,6 +211,8 @@ def RunSysbenchMemory(
 
     print("==>> Workload run complete!")
 
+    output["sysbenchversion"] = version
+
     return "success", WorkloadResultsMemory(
         sysbench_memory_output_schema.unserialize(output),
         sysbench_memory_results_schema.unserialize(results),
@@ -222,7 +228,8 @@ def RunSysbenchMemory(
 def RunSysbenchIo(
     params: SysbenchIoInputParams,
 ) -> typing.Tuple[str, typing.Union[WorkloadResultsIo, WorkloadError]]:
-    print(f"Sysbench version is: {get_sysbench_version()}")
+    version = get_sysbench_version()
+    print(f"Sysbench version is: {version}")
     print("==>> Running sysbench I/O workload ...")
 
     serialized_params = sysbench_io_input_schema.serialize(params)
@@ -239,6 +246,8 @@ def RunSysbenchIo(
         return "error", WorkloadError(error.args[0], error.args[1])
 
     print("==>> Workload run complete!")
+
+    output["sysbenchversion"] = version
 
     return "success", WorkloadResultsIo(
         sysbench_io_output_schema.unserialize(output),

--- a/arcaflow_plugin_sysbench/sysbench_schema.py
+++ b/arcaflow_plugin_sysbench/sysbench_schema.py
@@ -464,6 +464,11 @@ class SysbenchCommonOutputParams:
     parameters returned by sysbench benchmarks.
     """
 
+    sysbenchversion: typing.Annotated[
+        str,
+        schema.name("Sysbench version"),
+        schema.description("Version as reported by sysbench"),
+    ]
     totaltime: typing.Annotated[
         float,
         schema.name("Total time"),

--- a/tests/test_arcaflow_plugin_sysbench.py
+++ b/tests/test_arcaflow_plugin_sysbench.py
@@ -20,6 +20,7 @@ class SysbenchPluginTest(unittest.TestCase):
         plugin.test_object_serialization(
             sysbench_plugin.sysbench_cpu_output_schema.unserialize(
                 {
+                    "sysbenchversion": "sysbench 1.0.20",
                     "Numberofthreads": 2,
                     "Primenumberslimit": 10000,
                     "totaltime": 10.0008,
@@ -51,6 +52,7 @@ class SysbenchPluginTest(unittest.TestCase):
         plugin.test_object_serialization(
             sysbench_plugin.sysbench_memory_output_schema.unserialize(
                 {
+                    "sysbenchversion": "sysbench 1.0.20",
                     "Numberofthreads": 2,
                     "blocksize": "1KiB",
                     "totalsize": "102400MiB",
@@ -89,6 +91,7 @@ class SysbenchPluginTest(unittest.TestCase):
         plugin.test_object_serialization(
             sysbench_plugin.sysbench_io_output_schema.unserialize(
                 {
+                    "sysbenchversion": "sysbench 1.0.20",
                     "Numberofthreads": 2,
                     "NumberofIOrequests": 0,
                     "ReadWriteratioforcombinedrandomIOtest": 0,


### PR DESCRIPTION
## Changes introduced with this PR

Setting sysbench to a specific version in the Dockerfile, and adding the sysbench version to the output schema.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).